### PR TITLE
fix(lib): properly export types for SmartCaptcha (#1)

### DIFF
--- a/libs/yandex-smart-captcha/src/lib/types/index.ts
+++ b/libs/yandex-smart-captcha/src/lib/types/index.ts
@@ -1,4 +1,6 @@
 // Declare global window interface
+export {};
+
 declare global {
   interface Window {
     smartCaptcha: SmartCaptchaInstance;


### PR DESCRIPTION
Fixes #1 

This PR properly re-exports missing types (SmartCaptchaInstance, JavascriptErrorPayload) from the library's public API.
Also ensures correct `globalThis` typings for `window.smartCaptcha`.
Fixed ng-packagr build by converting `types/index.d.ts` into a proper module.
